### PR TITLE
jsonrpc: serialize writes to client connection

### DIFF
--- a/jsonrpc/client.go
+++ b/jsonrpc/client.go
@@ -47,6 +47,7 @@ type pendingRequest struct {
 type Client struct {
 	opts              *Options
 	conn              net.Conn
+	writeMu           sync.Mutex
 	msgID             int
 	msgIDMu           sync.Mutex
 	pendingRequests   map[int]pendingRequest
@@ -188,8 +189,10 @@ func (c *Client) Method(
 	}
 	c.pendingRequestsMu.Unlock()
 
+	c.writeMu.Lock()
 	_ = c.conn.SetWriteDeadline(time.Now().Add(writeTimeout))
 	_, err = c.conn.Write(msg)
+	c.writeMu.Unlock()
 	if err != nil {
 		c.Close()
 		return SocketError(fmt.Errorf("Failed to write to socket: %w", err))

--- a/jsonrpc/client_test.go
+++ b/jsonrpc/client_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -83,6 +84,55 @@ func (s *testSuite) TestMethodSync() {
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), "response", response)
 	require.Empty(s.T(), client.pendingRequests)
+}
+
+func (s *testSuite) TestMethodConcurrentWritesSerialized() {
+	s.server.OnRequest.Set(func(conn net.Conn, req *types.Request) *types.Response {
+		return &types.Response{
+			JSONRPC: types.JSONRPC,
+			ID:      &req.ID,
+			Result:  test.ToResult(req.ID),
+		}
+	})
+
+	var conn *concurrentWriteDetectingConn
+	client, err := Connect(&Options{
+		Dial: func() (net.Conn, error) {
+			netConn, err := s.dial()
+			if err != nil {
+				return nil, err
+			}
+			conn = newConcurrentWriteDetectingConn(netConn)
+			return conn, nil
+		},
+	})
+	require.NoError(s.T(), err)
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	const numRequests = 32
+	start := make(chan struct{})
+	errs := make(chan error, numRequests)
+	var wg sync.WaitGroup
+	for i := 0; i < numRequests; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			var response int
+			errs <- client.MethodBlocking(ctx, &response, "method")
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(s.T(), err)
+	}
+	require.Zero(s.T(), conn.concurrentWrites())
 }
 
 // Server returns an error nested in a `{ message: ...}` object.
@@ -259,4 +309,42 @@ func (s *testSuite) TestNotification() {
 	case <-time.After(1 * time.Second):
 		s.T().Fatal("timeout")
 	}
+}
+
+type concurrentWriteDetectingConn struct {
+	net.Conn
+
+	inWrite chan struct{}
+	mu      sync.Mutex
+	count   int
+}
+
+func newConcurrentWriteDetectingConn(conn net.Conn) *concurrentWriteDetectingConn {
+	return &concurrentWriteDetectingConn{
+		Conn:    conn,
+		inWrite: make(chan struct{}, 1),
+	}
+}
+
+func (c *concurrentWriteDetectingConn) Write(b []byte) (int, error) {
+	select {
+	case c.inWrite <- struct{}{}:
+		defer func() {
+			<-c.inWrite
+		}()
+	default:
+		c.mu.Lock()
+		c.count++
+		c.mu.Unlock()
+		return 0, fmt.Errorf("concurrent write detected")
+	}
+
+	time.Sleep(5 * time.Millisecond)
+	return c.Conn.Write(b)
+}
+
+func (c *concurrentWriteDetectingConn) concurrentWrites() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.count
 }


### PR DESCRIPTION
## Summary

This PR serializes writes from `jsonrpc.Client` to its underlying connection by adding a write mutex around the `SetWriteDeadline` + `Write` pair.

It also adds a regression test that launches concurrent `MethodBlocking` calls through a wrapped `net.Conn` which reports an error if writes overlap.

## Root cause

`jsonrpc.Client.Method` can be called from multiple goroutines, but it previously wrote request bytes directly to the shared `net.Conn` without write-side synchronization. Plain TCP usually masks this because writes are internally serialized, but other `net.Conn` implementations can expose the overlap.

One affected transport is `golang.org/x/crypto/ssh`'s `chanConn`: its `Write` delegates to `Channel.WriteExtended`, whose source currently notes that concurrent `WriteExtended` calls can be flagged by the race detector because a packet buffer is reused. Its `SetWriteDeadline` implementation also returns `ssh: tcpChan: deadline not supported`, so the deadline call does not protect the write path.

In downstream SSH-tunneled Electrum usage, concurrent `MethodBlocking` calls can corrupt the SSH packet stream, drop the connection, and cause all in-flight requests to fail together with `context canceled`.

## Evidence

A downstream reproducer run with `go run -race` reported races through this call path:

- `golang.org/x/crypto/ssh.(*channel).WriteExtended`
- `golang.org/x/crypto/ssh.(*channel).Write`
- `golang.org/x/crypto/ssh.(*chanConn).Write`
- `github.com/BitBoxSwiss/block-client-go/jsonrpc.(*Client).Method`

The regression test in this PR verifies the client no longer performs overlapping writes while preserving concurrent request/response handling.

## Impact

For TCP-only users, this should be behaviorally equivalent to the existing implementation, with one additional mutex acquire per request write. For SSH-tunneled or other connection implementations that are sensitive to concurrent writes, this avoids corrupting the transport and tearing down unrelated in-flight requests.

## Tests

- `go test ./jsonrpc`
- `go test ./...`
- `go test -race ./...`
